### PR TITLE
Fix send responsefile issue

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -25,7 +25,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "util/sendResponse.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
sendResponseFile has been throwing error because of autoload issue and a fix was done by add the file to auto load in composer so that the file no longer needs to be imported in every file where it is to be used it can be called from anywhere now without having to import the file 