### PR TITLE
feat(BAC-30): added endpoint to fetch questions by org_id

### DIFF
--- a/backend/app/Http/Controllers/QuestionsController.php
+++ b/backend/app/Http/Controllers/QuestionsController.php
@@ -47,4 +47,16 @@ class QuestionsController extends Controller
             return $this->errorResponse('Question not fetched', $e->getMessage());
         }
     }
+
+    public function getQuestionsByOrgId($org_id){
+        try {
+            $question = Question::where('org_id', $org_id)->get();
+            if(is_null($question)) {
+                return $this->errorResponse('No questions exist for this company', Response::HTTP_NOT_FOUND);
+            }
+            return $this->successResponse(true, 'OK', $question, 201);
+        } catch (Exception $e) {
+            return $this->errorResponse('Questions not fetched', $e->getMessage());
+        }     
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -90,6 +90,7 @@ Route::prefix("company")->group(function () {
 Route::prefix("question")->group(function () {
     Route::post('add', [QuestionsController::class, 'addManually']);
     Route::put('{questId}/{assId}/update', [QuestionsController::class, 'updateQuestion']);
+    Route::get('get/{org_id}', [QuestionsController::class, 'getQuestionsByOrgId']);
 });
 
 // Categories routes operation
@@ -97,7 +98,7 @@ Route::prefix("category")->group(function () {
     Route::put('{catId}/update', [CategoryController::class, 'updateCategory']);
 });
 
-//AddEmployeeByCSV
+//Employee Routes
 Route::prefix('employee')->group(function () {
     Route::post('add', [EmployeeController::class, 'addEmpCSV']);
 });


### PR DESCRIPTION
#### Task reference
BAC-30: Fetch Questions by org_id
#### Summary
At the endpoint `api/questions/get/{org_id}` it returns all questions where the org_id belongs to an id inside the company table
#### Implementation details
The endpoint is routed to the getQuestionsByOrgId($org_id) method inside the QuestionsController class, where all the questions with that `org_id` will be fetched and returned.
#### How to test
Can be accessed from the route like this `api/questions/get/{abc123}`, where "abc123" is an id from company table.
#### References 
None.
