### PR TITLE
fix: removed global auth middleware

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -30,7 +30,6 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\IsLoggedIn::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -117,8 +117,3 @@ Route::prefix('employee')->group(function () {
 Route::fallback(function () {
     return response()->json(['message' => 'no Route matched with those values!'], 404);
 });
-
-Route::post("/midd", function(Request $req){
-    echo "welcome";
-    print_r($req->user);
-})->middleware("isloggedin");


### PR DESCRIPTION
fix: removed global auth middleware.

`isloggedin` middleware  was register within the web middleware enabling all route towards the web to be authenticated which was a huge bug.