### PR TITLE
fix link font size on mobile

### DIFF
--- a/frontend/src/main/compnents/sections/footer/Footer.module.css
+++ b/frontend/src/main/compnents/sections/footer/Footer.module.css
@@ -176,7 +176,7 @@
   }
   .link {
     font-weight: 200;
-    font-size: 5px;
+    font-size: 10px;
 
     gap: 10px;
   }
@@ -196,7 +196,7 @@
   .right {
     font-family: "Inter";
     font-weight: 200;
-    font-size: 3px;
+    font-size: 4px;
     color: #40403e;
     line-height: 10px;
   }


### PR DESCRIPTION
fix link font size on the footer
<img width="522" alt="Screenshot 2022-11-20 at 6 01 36 PM" src="https://user-images.githubusercontent.com/95039198/202915477-41faee42-9928-46f0-8594-79abdce6209a.png">

