### PR TITLE
Feat(BAC-57) implement get available and completed user assessment by…

### DIFF
--- a/backend/app/Http/Controllers/UserAssessmentController.php
+++ b/backend/app/Http/Controllers/UserAssessmentController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\Employee;
 use App\Models\UserAssessment;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use App\Http\Requests\UserAssessmentRequest;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Http\JsonResponse;
-use App\Models\UserAssessment;
 
 class UserAssessmentController extends Controller
 {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -133,8 +133,8 @@ Route::prefix("user-assessment")->group(function () {
     Route::post('/accept/{assessmentId}/{employmentId}', [UserAssessmentController::class, 'acceptUserAssessment']);
     Route::get('/org/{orgId}', [UserAssessmentController::class, 'getOrgUserAssessmentByPerformance']);
     Route::get('/{employee_id}/completed', [UserAssessmentController::class, 'getEmployeeCompletedAssessment'])->middleware("isloggedin");
-    Route::get('{org_id}/available', [UserAssessmentController::class, 'GetOrgAvailableAssessment']);
-    Route::get('{org_id}/completed', [UserAssessmentController::class, 'GetOrgCompletedAssessment']);
+    Route::get('{org_id}/org-available', [UserAssessmentController::class, 'GetOrgAvailableAssessment']);
+    Route::get('{org_id}/org-completed', [UserAssessmentController::class, 'GetOrgCompletedAssessment']);
 });
 
 Route::fallback(function () {


### PR DESCRIPTION
#### Task reference
This task is based on task issue to me me with code BAC-57-GetOrgAvailableAssessment and BAC-58-GetOrgCompletedAssessment
#### Summary
This s done to create an endpoint that return available user assessment by org_id and  completed user assessment by org_id
#### Implementation details
it has end points as stated below
GetOrgAvailableAssessment - /api/user-assessment/{org_id}/org-available
GetOrgCompletedAssessment - api/user-assessment/{org_id}/org-completed
#### How to test
navigate to the above endpoints
#### References 
GetOrgAvailableAssessment fail
![get_av_fals](https://user-images.githubusercontent.com/29203046/203848823-22b18003-9ccc-490e-9991-910d5c44c81b.png)

GetOrgAvailableAssessment success
![get_ava_true](https://user-images.githubusercontent.com/29203046/203848826-51bc8659-ecc8-4187-9272-0050a6330049.png)

GetOrgCompletedAssessment fail
![get_com_fal](https://user-images.githubusercontent.com/29203046/203848830-de1f160e-1f38-4af7-8c11-bed542e2ecc4.png)

GetOrgCompletedAssessment success
![get_com_true](https://user-images.githubusercontent.com/29203046/203848833-d279f9db-9858-436a-903f-399314c326e0.png)

