### PR TITLE
FE-74-styles:remove fontsize on HeroText

### DIFF
--- a/frontend/src/main/components/BioMedical/BioMedicalHero.jsx
+++ b/frontend/src/main/components/BioMedical/BioMedicalHero.jsx
@@ -58,7 +58,6 @@ const HeroText = styled.div`
   padding-bottom: 219px;
   p {
     color: #605e5c;
-    font-size: 24px;
     line-height: 34.57px;
     letter-spacing: 3%;
     margin-bottom: 48px;


### PR DESCRIPTION
This PR is a update of [https://github.com/workshopapps/engineerprofile360.web/pull/307](https://github.com/workshopapps/engineerprofile360.web/pull/307)

This PR fixes: 
https://linear.app/team-axle-skript-project/issue/FRO-74/marketing-landing-page-biomedical-engineering


Removed the fontsize on the Hero Text - Biomedical Engineering Landing Page


