### PR TITLE
Bac fix: remove pagination from get interviews by stack id

### DIFF
--- a/backend/app/Http/Controllers/InterviewController.php
+++ b/backend/app/Http/Controllers/InterviewController.php
@@ -47,7 +47,7 @@ class InterviewController extends Controller
 
     public function getInterviewByStack($stackId) {
         try {
-            $interviews = Interview::where('stack_id', $stackId)->paginate(5);
+            $interviews = Interview::where('stack_id', $stackId)->get();
          
             if( !$interviews) {
                 return $this->sendResponse(


### PR DESCRIPTION
remove pagination from endpoint to meet up with scroll system on Page design

api response after fix
![ret](https://user-images.githubusercontent.com/73889664/205447967-1c5b6526-ac6a-48bb-8f3f-9f059af489c2.png)
