### PR TITLE
Fix for csv-parser error and employee migration

### DIFF
--- a/backend/database/migrations/2022_11_16_133927_create_employees_table.php
+++ b/backend/database/migrations/2022_11_16_133927_create_employees_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('employees', function (Blueprint $table) {
             $table->uuid('id')->unique();
-            $table->string("email")->unique();
+            $table->string("email");
             $table->string("fullname");
             $table->string("username");
             $table->string("hash")->nullable();


### PR DESCRIPTION
#### Summary
Fix for CSV-Parser
- Removed password object from parser to generate random password for each entry.
- Added Uid to the parser instead of integer ids

Fix for migration file
- Employee email field being a primary key makes it unable for an employee to belong to more than one organization. The check to make sure no duplicate email exist for any particular organization is already in place when adding employees, either by csv or manually. I took permission from Ben before doing this 

Others:
Removed the old rough comments on confirmCSV method: It's not being used currently, so I'm removing the comments to keep it clean. But not deleting the whole endpoint in case 

