### PR TITLE
Request demo

### DIFF
--- a/backend/app/Helper/Helper.php
+++ b/backend/app/Helper/Helper.php
@@ -155,8 +155,15 @@ class Helper extends Controller
         }
     }
 
-    public function notifyEmployee($emp_email, $emp_id)
+    public function demoRequests($to, $type, $userName, $companyName, $companyEmail, $companyPhone)
     {
-        return "hey";
+        try {
+            $mail = new Mailer();
+            $mail->requetsDemo($to, $type, $userName, $companyName, $companyEmail, $companyPhone);
+            return true;
+        } catch (\Exception $e) {
+            Log::error("Could not send requests demo link" . $e->getMessage());
+            return false;
+        }
     }
 }

--- a/backend/app/Http/Controllers/RequestDemoFromUsers.php
+++ b/backend/app/Http/Controllers/RequestDemoFromUsers.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helper\Helper;
+use Illuminate\Http\Request;
+
+class RequestDemoFromUsers extends Controller
+{
+
+    public function __construct()
+    {
+        $this->helper = new Helper();
+        $this->Eval360_EMAIL = "alumonabenaiah71@gmail.com";
+    }
+
+    public function sendRequestsDemo(Request $req){
+        try {
+            
+            $payload = json_decode($req->getContent(), true);
+
+            if(!isset($payload["username"]) || !isset($payload["companyName"]) || !isset($payload["companyEmail"]) || !isset($payload["companyPhone"])){
+                return $this->sendResponse(true, "some inputs are missing", "There was a problem with your submission, please try again", null, 400);
+            }
+
+            if(empty($payload["username"]) || empty($payload["companyName"]) || empty($payload["companyEmail"]) || empty($payload["companyPhone"])){
+                return $this->sendResponse(true, "some inputs are missing", "There was a problem with your submission, please try again", null, 400);
+            }
+
+            // validate email
+            $userName = $payload["username"];
+            $companyName = $payload["companyName"];
+            $companyEmail = $payload["companyEmail"];
+            $companyPhone = $payload["companyPhone"];
+            $userMail = $companyEmail;
+
+            // send mail to demo user.
+            $this->helper->demoRequests($userMail, "demo_user", $userName, $companyName, $companyEmail, $companyPhone);
+            // sends mail to eval360 admin
+            $this->helper->demoRequests($this->Eval360_EMAIL, "eval360_admin",$userName, $companyName, $companyEmail, $companyPhone);
+
+            return $this->sendResponse(false, null, "requests demo sent successfully", null, 200);
+
+        } catch (\Exception $e) {
+            return $this->sendResponse(true, "something went wrong: ".$e->getMessage(), "something went wrong sending requests demo, please try later", null, 500);
+        }
+    }
+}

--- a/backend/app/Mail/RequestDemo.php
+++ b/backend/app/Mail/RequestDemo.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class RequestDemo extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+
+    public $mailData;
+
+    public function __construct($mailData)
+    {
+        $this->mailData = $mailData;
+    }
+
+    /**
+     * Get the message envelope.
+     *
+     * @return \Illuminate\Mail\Mailables\Envelope
+     */
+    public function envelope()
+    {
+        return new Envelope(
+            subject: 'Request Demo',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     *
+     * @return \Illuminate\Mail\Mailables\Content
+     */
+    public function content()
+    {
+        return new Content(
+            view: 'emails.requestsDemo',
+        );
+    }
+
+
+    public function build()
+    {
+        return $this->subject('Demo Requests')->view('requestsDemo');
+    }
+
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array
+     */
+    public function attachments()
+    {
+        return [];
+    }
+}

--- a/backend/resources/views/emails/requestsDemo.blade.php
+++ b/backend/resources/views/emails/requestsDemo.blade.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Eval360 Demo Requests</title>
+</head>
+<body>
+    
+    @if ($mailData["type"] === "eval360_admin")
+        <h1>Demo Requests</h1>
+        <br>
+        <p>A client with the following details: </p>
+        <p> Name: {{$mailData["name"]}} </p>
+        <p> Company Name: {{$mailData["company_name"]}} </p>
+        <p> Company Email: {{$mailData["company_email"]}} </p>
+        <p> Company Phonenumber: {{$mailData["company_phone"]}} </p>
+        <br>
+        <p>Has requested to demo of your application, kindly reach out to him.</p>
+    @else
+        <h1>Demo Requests</h1>
+        <br>
+        <p>Your requests for demo has been received and we would get back to you by mail shortly.</p>
+    @endif
+</body>
+</html>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Admin\StackController;
 use App\Http\Controllers\AuthenticateController;
 use App\Http\Controllers\UserAssessmentController;
 use App\Helper\Helper;
+use App\Http\Controllers\RequestDemoFromUsers;
 use Illuminate\Auth\Events\Authenticated;
 
 // util functions
@@ -234,6 +235,10 @@ Route::prefix("user-assessment")->group(function () {
     Route::put('/{id}/update', [UserAssessmentController::class, 'updateUserAssessment']);
     Route::delete('/{id}/delete', [UserAssessmentController::class, 'deleteUserAssessment']);
 });
+
+
+// send requests demo
+Route::post("/request-demo", [RequestDemoFromUsers::class, "sendRequestsDemo"]);
 
 Route::fallback(function () {
     return response()->json(['message' => 'no Route matched with those values!'], 404);

--- a/backend/util/sendMail.php
+++ b/backend/util/sendMail.php
@@ -2,6 +2,7 @@
 
 use App\Mail\Onboarding;
 use App\Mail\PasswordReset;
+use App\Mail\RequestDemo;
 use App\Mail\Signup;
 use App\Mail\Verification;
 use Illuminate\Support\Facades\Mail;
@@ -84,6 +85,24 @@ class Mailer
             Mail::to($to)->send(new PasswordReset($mailData));
         } catch (\Exception $e) {
             echo ("Something went wrong sending mail " . $e->getMessage());
+        }
+    }
+
+
+    public function requetsDemo($to,$type, $userName, $companyName, $companyEmail, $companyPhone)
+    {
+        $mailData = [
+            "name" => $userName,
+            "company_name" => $companyName,
+            "company_email" => $companyEmail,
+            "company_phone" => $companyPhone,
+            "type"=>$type
+        ];
+
+        try {
+            Mail::to($to)->send(new RequestDemo($mailData));
+        } catch (\Exception $e) {
+            return print("Something went wrong sending mail " . $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
added an endpoint for a user to requests for `eval360` demo.

It can be accessible via `POST` to `/api/request-demo` with the following payload.

```js
{
    "username": "Gerry Louch",
    "companyName": "HyDro",
    "companyEmail": "fawevi3454@dni8.com",
    "companyPhone": "1234567890"
}
```